### PR TITLE
Fix #8: Add syntax highlighting to input textarea

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,9 @@
     <title>HTML Tutorial</title>
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <script type="module" src="https://pyscript.net/releases/2025.8.1/core.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.20/codemirror.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.20/mode/python/python.min.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.20/codemirror.min.css">
 </head>
 <body>
     <script type="py" src="./main.py" config="./pyscript.json"></script>

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 import html_helpers
 from html_helpers import br, button, div, em, h1, h2, p, textarea
-from pyscript import document, when
+from pyscript import document, when, window
 from pyscript.web import Element
 
 
@@ -32,7 +32,14 @@ def _main() -> None:
         output_area := div(),
         error_area := div(),
     )
-    when("click", submit_button, handler=lambda _: _evaluate_solution(code_area.value, output_area, error_area))
+    editor = window.CodeMirror.fromTextArea(
+        code_area,
+        {
+            "lineNumbers": True,
+            "mode": "python",
+        },
+    )
+    when("click", submit_button, handler=lambda _: _evaluate_solution(editor.getValue(), output_area, error_area))
 
 
 _main()


### PR DESCRIPTION
I couldn't figure out how to load CodeMirror as a module using the pyscript.json config (everything I tried produced AttributeErrors), so I added it as a script tag instead.

I'll create an issue for this, but if no one can figure out how to make it work as a module, the current way should be fine as well.